### PR TITLE
Update steam-workshop.md - Local thumbnail vs Cloud

### DIFF
--- a/docs/custom-content/steam-workshop.md
+++ b/docs/custom-content/steam-workshop.md
@@ -35,7 +35,7 @@ In the next section, you can either upload your files to an external site and in
 <center>![Workshop Export Browser](/img/steam-workshop/browser.png)</center>
 
 !!!important "Image Upload"
-    If you don’t put in an image for the thumbnail, you will get an error and the mod won’t upload, so don’t forget this step!
+    If you don’t put in an image for the thumbnail, you will get an error and the mod won’t upload, so don’t forget this step! Also, make sure your thumbnail file is Local and not in the Steam Cloud. Cloud files could freeze your upload with no confirmation at all.  This is just for the thumbnail file.
 
 Next, check mark the game type for your mod. Is your mod full of custom models that you created from scratch? Then you want to check that box. Is your mod a board game, but also a role-playing game? Then check both of those.
 


### PR DESCRIPTION
When I tried to upload my first mod with a Cloud Thumbnail, I received the "Mod is being Uploaded" message and then nothing else for an hour.  Only after digging around in the Forums did I find the suggestion of designating the uploaded thumbnail file as Local instead of Cloud.  When I did that, the mod uploaded immediately.  Thank you for considering adding this to the doc.  Z