### PR TITLE
 Made the text instructions more specific 

### DIFF
--- a/docs/custom-content/custom-assetbundle.md
+++ b/docs/custom-content/custom-assetbundle.md
@@ -109,7 +109,7 @@ Once you are finished creating your asset, you must turn it into a pre-fab.
     </video>
 </center>
 
-Give it a unique name.
+Then, while selecting the prefab you wish to export in Unity look at the Inspector tab and scroll to the bottom until you see a dropdown labeled "AssetBundle". Name it whatever you would like your final unity.3d file to be named.
 
 <center>
     <video controls


### PR DESCRIPTION
Do this if you encounter "No assetbundle has been set for this build" error

Reasoning for change:
As a regular modder and software developer I expect a written guide to contain all of the steps necessary in written form, not hidden away in a gif. The gif is nice to have but the written instructions should be primary.